### PR TITLE
Modificado verificação de retorno de queries (Warning no PHP 7.2+)

### DIFF
--- a/app/libraries/Auth.php
+++ b/app/libraries/Auth.php
@@ -492,7 +492,7 @@ class Auth
     public function email_exists($email)
     {
         $query = $this->account->find_by('email', $email);
-        if (@count($query) == 0)
+        if (empty($query))
             return FALSE;
         else
             return TRUE;

--- a/app/modules/admin/controllers/Events.php
+++ b/app/modules/admin/controllers/Events.php
@@ -119,7 +119,7 @@ class Events extends Authenticated_admin_controller
             if ($id == null)
                 $this->set_message(wpn_lang('wpn_message_inexistent'), 'info', 'admin/events');
             $query = $this->post->find_by(array('id' => $id, 'page' => 2));
-            if(count($query) == 0)
+            if(empty($query))
                 $this->set_message(wpn_lang('wpn_message_inexistent'), 'info', 'admin/events');
             $this->set_var('id', $id);
             $this->set_var('row', $query);

--- a/app/modules/admin/controllers/Menus.php
+++ b/app/modules/admin/controllers/Menus.php
@@ -326,7 +326,7 @@ class Menus extends Authenticated_admin_controller
     private function get_titulo_menu($menu_id)
     {
         $query = $this->menu->find($menu_id);
-        if(count($query))
+        if(!empty($query))
             return $query->nome;
         else
             return '<span class="label label-danger">Error</span>';

--- a/app/modules/admin/controllers/Pages.php
+++ b/app/modules/admin/controllers/Pages.php
@@ -118,7 +118,7 @@ class Pages extends Authenticated_admin_controller
             if ($id == null)
                 $this->set_message('Página inexistente.', 'info', 'admin/pages');
             $query = $this->post->find_by(array('id' => $id, 'page' => 1));
-            if(count($query) == 0)
+            if(empty($query))
                 $this->set_message(wpn_lang('wpn_message_inexistent'), 'info', 'admin/pages');
             $this->set_var('id', $id);
             $this->set_var('row', $query);

--- a/app/modules/admin/controllers/Posts.php
+++ b/app/modules/admin/controllers/Posts.php
@@ -135,7 +135,7 @@ class Posts extends Authenticated_admin_controller
             if ($id == null)
                 $this->set_message(wpn_lang('wpn_message_inexistent'), 'info', 'admin/posts');
             $query = $this->post->find_by(array('id' => $id, 'page' => 0));
-            if(count($query) == 0)
+            if(empty($query))
                 $this->set_message(wpn_lang('wpn_message_inexistent'), 'info', 'admin/posts');
             // Prepara a lista de categorias.
             $query_cat = $this->category->select('id, title')->find_all();


### PR DESCRIPTION
O método count() a partir do PHP 7.2 retorna um WARNING caso o parâmetro não seja um array, no caso das queries, há chances do retorno ser um valor null, dando motivo para o WARNING.